### PR TITLE
Tmux pane management.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ Makefile
 *.pyc
 /.git
 .DS_Store
+/.virtualenv
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ This feature could be turned on and off by config option in config.cfg as:
 ........
 tmux_support=true/false
 ```
+
+Note that when you press `e` in detail view,  all other panes in current tmux
+window except for the detail pane will be closed before the new edit pane is
+created, so that you can edit solution for another problem seamlessly without
+manually exiting vim and closing the edit pane.
+
 #### Code Snippet
 Two code snippets can be used when creating code file.  
 You can create files ``before`` and ``after`` in ``~/.config/leetcode/snippet``. Code snippet in ``before``

--- a/leetcode/editor.py
+++ b/leetcode/editor.py
@@ -25,7 +25,14 @@ def is_inside_tmux():
     return 'TMUX' in os.environ
 
 def open_in_new_tmux_window(edit_cmd):
-    #cmd = "tmux split-window -h '%s'" % edit_cmd
+    # close other panes if exist, so that the detail pane is the only pane
+    try:
+        output = subprocess.check_output("tmux list-panes | wc -l", shell=True)
+        num_pane = int(output)
+        if num_pane > 1:
+            subprocess.check_call("tmux kill-pane -a", shell=True)
+    except:
+        pass
     cmd = "tmux split-window -h"
     os.system(cmd)
     cmd = "tmux send-keys '%s' C-m" % edit_cmd


### PR DESCRIPTION
Close previously opened edit pane (if exists) when editing in tmux mode, so that
we always keep two panes (detail and edit) side-by-side.