### PR TITLE
fix tmxu send-keys

### DIFF
--- a/leetcode/editor.py
+++ b/leetcode/editor.py
@@ -35,5 +35,5 @@ def open_in_new_tmux_window(edit_cmd):
         pass
     cmd = "tmux split-window -h"
     os.system(cmd)
-    cmd = "tmux send-keys '%s' C-m" % edit_cmd
+    cmd = "tmux send-keys -t right '%s' C-m" % edit_cmd
     os.system(cmd)


### PR DESCRIPTION
Specify the target pane (right) to send keys to.

I do not know why we did not need this previously. I recently reinstalled OS and everything, but my tmux version is not changed (2.1). Very strange.