### PR TITLE
Fixed Import Errors

### DIFF
--- a/leetcode/views/home.py
+++ b/leetcode/views/home.py
@@ -3,7 +3,7 @@ import re
 import json
 import urwid
 from .viewhelper import vim_key_map
-from ..config import TAG_FILE
+from ..helper.config import TAG_FILE
 
 
 class ItemWidget(urwid.WidgetWrap):

--- a/leetcode/views/loading.py
+++ b/leetcode/views/loading.py
@@ -2,7 +2,7 @@ import time
 from threading import Thread
 import urwid
 from .viewhelper import delay_refresh
-from leetcode.model import EasyLock
+from ..helper.model import EasyLock
 
 
 class LoadingView(urwid.Frame):


### PR DESCRIPTION
The files 'leetcode/views/home.py' and 'leetcode/views/loading.py' were throwing Import error due to incorrect paths in import statements. This was causing the program to terminate.